### PR TITLE
fix: potential clone-dir collision when running update after install

### DIFF
--- a/packages/boilermaker_core/src/commands/update.rs
+++ b/packages/boilermaker_core/src/commands/update.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::Parser;
 use color_eyre::Result;
 use color_eyre::eyre::eyre;
@@ -27,9 +25,16 @@ pub async fn update(app_state: &AppState, cmd: &Update) -> Result<()> {
 
     info!("Updating template #{}: {}", templ.id, templ.name);
 
-    // TODO: fix template_dir to be new hash based path
-    let template_dir = PathBuf::from(templ.template_dir.clone());
+    let hash = templ
+        .sha256_hash
+        .as_deref()
+        .ok_or_else(|| eyre!("💥 Template #{} is missing a sha256_hash", templ.id))?;
+    let template_dir = crate::template::get_template_dir_path(hash)?;
     let tmp_clone_dir = make_tmp_dir_from_url(&templ.repo);
+
+    // Avoid clone dir collisions if update is run right after install. This won't be needed once we
+    // patch clone_repo's TODOs.
+    clean_dir(&tmp_clone_dir)?;
 
     let clone_ctx = CloneContext::new(
         &templ.repo,


### PR DESCRIPTION
This fixes an issue with our install / update workflow.

## Issue

When using `boil install ...`, we'll clone a template git repository to a temp directory that is deterministic. If we run `boil update ...` for the same template right after (or as long as the temp directory is around), we'll get an error.

```
❯ cargo run --bin boil update 1
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/boil update 1`
[📦 INFO] Updating template #1: hello-world-rust
Error:
   0: 💥 Failed to clone repository: '/var/folders/5d/qvxdjhb147v2g7cgh7n8g51m0000gn/T/boil-hello-world' exists and is not an empty directory; class=Invalid (3); code=Exists (-4)

Location:
   packages/boilermaker_core/src/template/lib.rs:74
```

That's because we:

1. don't clean up after running the install command,
2. `clone_repo` has a [relevant TODO](https://github.com/yeajustmars/boilermaker/blob/913eeb1731b60859863230b3bffccf885939d85e/packages/boilermaker_core/src/template/lib.rs#L43): the long-term fix is to do a fetch + hard-reset if the repository already exists.

## Fix

The quick-fix is to "clean up" the repo before running `clone_repo`. ✅

I think there's more to it, but I'd rather have a *quick* fix at this point, than refactoring install & update. YMMV. :)

This also addresses a TODO in update, to use the template's sha265 column in the DB. ✅ 